### PR TITLE
Update states.json

### DIFF
--- a/docs/week02/sample-json/states.json
+++ b/docs/week02/sample-json/states.json
@@ -49,7 +49,7 @@
 		},
 		{
 			"name": "Illinois",
-			"abbreviation": "IL"
+			"abbreviation": "LL"
 		},
 		{
 			"name": "Indiana",


### PR DESCRIPTION
Modified abbreviation of Illinois to be incorrect on purpose so that the matching function returns a value.