### PR TITLE
Update messaging.rst

### DIFF
--- a/docs/week11/messaging.rst
+++ b/docs/week11/messaging.rst
@@ -491,7 +491,7 @@ from it, but we do need to import the ``StrictRedis`` and ``HotQueue`` classes. 
     from redis import StrictRedis
 
     q = HotQueue("queue", host='172.17.0.1', port=6379, db=1)
-    rd = redis.StrictRedis(host='172.17.0.1', port=6379, db=0)
+    rd = StrictRedis(host='172.17.0.1', port=6379, db=0)
 
     def _generate_jid():
         return str(uuid.uuid4())


### PR DESCRIPTION
Since `from redis import StrictRedis`, constructor should be called as StrictRedis() instead of redis.StrictRedis()